### PR TITLE
Fix for missing CDATA strings from asArray option

### DIFF
--- a/XmlIterator/XmlIterator.php
+++ b/XmlIterator/XmlIterator.php
@@ -97,7 +97,7 @@ class XmlIterator implements \Iterator
         // convert to array for ease of use
         $current = simplexml_import_dom($this->doc->importNode($this->reader->expand(), true));
         if ($this->options["asArray"]) {
-            return json_decode(json_encode($current), true);
+            return json_decode(json_encode(new \SimpleXMLElement($current->asXML(), LIBXML_NOCDATA)), true);
         } else {
             return $current;
         }


### PR DESCRIPTION
- as per http://www.php.net/manual/en/function.json-encode.php#97008
