### PR TITLE
Add #[\ReturnTypeWillChange] attribute for php8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "halilim/xml-iterator",
+  "name": "glsv/xml-iterator",
   "type": "library",
   "description": "XML Reader to simplexml/array iterator with low memory usage and an acceptable level of ease of use.",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0-dev"
+      "dev-master": "develop"
     }
   },
   "config": {

--- a/src/Utf8Filter.php
+++ b/src/Utf8Filter.php
@@ -16,6 +16,7 @@ class Utf8Filter extends php_user_filter
      *
      * @link http://stackoverflow.com/a/3466609/372654
      */
+    #[\ReturnTypeWillChange]
     public function filter($in, $out, &$consumed, $closing)
     {
         while ($bucket = stream_bucket_make_writeable($in)) {

--- a/src/XmlIterator.php
+++ b/src/XmlIterator.php
@@ -94,6 +94,7 @@ class XmlIterator implements Iterator
      * @link http://stackoverflow.com/a/1835324/372654
      * @return false|array|\SimpleXMLElement
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $node = $this->reader->expand();
@@ -121,6 +122,7 @@ class XmlIterator implements Iterator
      * @link http://php.net/manual/en/iterator.next.php
      * @return void Any returned value is ignored.
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->reader->next($this->delimiterTagName)) {
@@ -133,6 +135,7 @@ class XmlIterator implements Iterator
      * @link http://php.net/manual/en/iterator.key.php
      * @return int scalar on success, or null on failure.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -144,6 +147,7 @@ class XmlIterator implements Iterator
      * @return boolean The return value will be casted to boolean and then evaluated.
      *       Returns true on success or false on failure.
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->reader->name === $this->delimiterTagName;
@@ -155,6 +159,7 @@ class XmlIterator implements Iterator
      * @throws \Exception
      * @return void Any returned value is ignored.
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $uri = $this->xmlFileUri;


### PR DESCRIPTION
I was looking for a library to work with xml and found your package. 
This works really well, but there are return type notices when I run it on php8.

They can be suppressed by adding #[\ReturnTypeWillChange] attributes to problematic methods.